### PR TITLE
32 adapt interview logic for different profiling order

### DIFF
--- a/user-study/gpt4-responses/v2_interview/heatmap_descriptions.csv
+++ b/user-study/gpt4-responses/v2_interview/heatmap_descriptions.csv
@@ -1,0 +1,3 @@
+id,heatmap_description
+1,"In the heatmap image, the red areas appear to highlight the bird’s head, particularly focusing on the crest and the beak region. The intensity of red suggests these features are significant for the AI model's prediction of the bird species."
+7,"In the heatmap image provided, the areas of the bird that are highlighted in red appear to be concentrated on the head, specifically around the bird's face, beak, and throat area. This suggests that the artificial intelligence model identifies these parts of the bird as important features for determining the species of the bird."

--- a/user-study/gpt4-responses/v2_interview/heatmap_descriptions.csv
+++ b/user-study/gpt4-responses/v2_interview/heatmap_descriptions.csv
@@ -1,3 +1,4 @@
-id,heatmap_description
-1,"In the heatmap image, the red areas appear to highlight the bird’s head, particularly focusing on the crest and the beak region. The intensity of red suggests these features are significant for the AI model's prediction of the bird species."
-7,"In the heatmap image provided, the areas of the bird that are highlighted in red appear to be concentrated on the head, specifically around the bird's face, beak, and throat area. This suggests that the artificial intelligence model identifies these parts of the bird as important features for determining the species of the bird."
+"id","heatmap_description"
+1,"The heatmap highlights the bird's head and beak in red."
+5,"The red areas on the heatmap mainly highlight the bird's head, eye, and beak."
+7,"The red areas highlighted by the heatmap are focused on the bird's head, particularly around the eye and beak."

--- a/user-study/gpt4-responses/v2_interview/utils/api_interactions.py
+++ b/user-study/gpt4-responses/v2_interview/utils/api_interactions.py
@@ -33,7 +33,3 @@ def generate_heatmap_descriptions(question_IDs:[int]) -> None:
     heatmaps_df.sort_values(by=['id'], inplace=True)
     heatmaps_df.reset_index()
     heatmaps_df.to_csv("heatmap_descriptions.csv", na_rep='NA', index=False, quoting=csv.QUOTE_NONNUMERIC)
-
-def get_heatmap_descriptions() -> dict[int, str]:
-    heatmaps_df = pd.read_csv("heatmap_descriptions.csv")
-    return heatmaps_df.to_dict('records')

--- a/user-study/gpt4-responses/v2_interview/utils/api_interactions.py
+++ b/user-study/gpt4-responses/v2_interview/utils/api_interactions.py
@@ -1,0 +1,36 @@
+import openai
+import pandas as pd
+
+from .api_messages import get_msg, get_msg_with_image
+from .prompts import USER_INTRO_4, USER_HEATMAP_4
+from .questionnaire import find_imagepaths
+
+def get_llm_heatmap_description(image_path:str) -> str:
+    response = openai.ChatCompletion.create(
+            model = "gpt-4-vision-preview",
+            max_tokens = 400,
+            messages = 
+                (get_msg(role="user", prompt=USER_INTRO_4)) +\
+                get_msg_with_image(role="user", prompt=USER_HEATMAP_4, image=image_path)
+        )
+    actual_response = response["choices"][0]["message"]["content"]
+    return actual_response
+
+def generate_heatmap_descriptions(question_IDs:[int]) -> None:
+    heatmaps_df = pd.read_csv("heatmap_descriptions.csv")
+
+    # filter out IDs of questions that already have a heatmap description
+    existing_descriptions = heatmaps_df['id'].tolist()
+    new_descriptions = set(question_IDs).difference(existing_descriptions)
+
+    image_paths = find_imagepaths("prediction_questions.csv", new_descriptions)
+
+    for (q_index, q_path) in image_paths:
+        description = get_llm_heatmap_description(q_path)
+        #description = "description " + str(q_index)
+        heatmaps_df.loc[len(heatmaps_df)] = {'id': q_index, 'heatmap_description': description}
+
+    heatmaps_df.sort_values(by=['id'], inplace=True)
+    heatmaps_df.reset_index()
+    heatmaps_df.to_csv("heatmap_descriptions.csv", na_rep='NA', index=False)
+

--- a/user-study/gpt4-responses/v2_interview/utils/api_interactions.py
+++ b/user-study/gpt4-responses/v2_interview/utils/api_interactions.py
@@ -1,8 +1,9 @@
 import openai
 import pandas as pd
+import csv
 
 from .api_messages import get_msg, get_msg_with_image
-from .prompts import USER_INTRO_4, USER_HEATMAP_4
+from .prompts import USER_INTRO_4, USER_HEATMAP_4, TOKENS_LOW
 from .questionnaire import find_imagepaths
 
 def get_llm_heatmap_description(image_path:str) -> str:
@@ -11,7 +12,7 @@ def get_llm_heatmap_description(image_path:str) -> str:
             max_tokens = 400,
             messages = 
                 (get_msg(role="user", prompt=USER_INTRO_4)) +\
-                get_msg_with_image(role="user", prompt=USER_HEATMAP_4, image=image_path)
+                get_msg_with_image(role="user", prompt=USER_HEATMAP_4+TOKENS_LOW, image=image_path)
         )
     actual_response = response["choices"][0]["message"]["content"]
     return actual_response
@@ -27,10 +28,9 @@ def generate_heatmap_descriptions(question_IDs:[int]) -> None:
 
     for (q_index, q_path) in image_paths:
         description = get_llm_heatmap_description(q_path)
-        #description = "description " + str(q_index)
         heatmaps_df.loc[len(heatmaps_df)] = {'id': q_index, 'heatmap_description': description}
 
     heatmaps_df.sort_values(by=['id'], inplace=True)
     heatmaps_df.reset_index()
-    heatmaps_df.to_csv("heatmap_descriptions.csv", na_rep='NA', index=False)
+    heatmaps_df.to_csv("heatmap_descriptions.csv", na_rep='NA', index=False, quoting=csv.QUOTE_NONNUMERIC)
 

--- a/user-study/gpt4-responses/v2_interview/utils/api_interactions.py
+++ b/user-study/gpt4-responses/v2_interview/utils/api_interactions.py
@@ -7,6 +7,14 @@ from .prompts import USER_INTRO_4, USER_HEATMAP_4, TOKENS_LOW
 from .questionnaire import find_imagepaths
 
 def get_llm_heatmap_description(image_path:str) -> str:
+    """Uses LLM to generate heatmap description for image found under the given path.
+    
+    Args:
+        image_path (str) : path to heatmap image
+    
+    Returns:
+        (str) : LLM-generated description
+    """
     response = openai.ChatCompletion.create(
             model = "gpt-4-vision-preview",
             max_tokens = 400,
@@ -18,6 +26,13 @@ def get_llm_heatmap_description(image_path:str) -> str:
     return actual_response
 
 def generate_heatmap_descriptions(question_IDs:[int]) -> None:
+    """For questions/heatmaps indicated by given IDs, asks LLM to generate descriptions and saves them to a csv file.
+    Only IDs for which no description exists yet will be considered. The CSV file will be sorted by question ID.
+    
+    Args:
+        question_IDs ([int]) : list of question IDs
+        
+    """
     heatmaps_df = pd.read_csv("heatmap_descriptions.csv")
 
     # filter out IDs of questions that already have a heatmap description

--- a/user-study/gpt4-responses/v2_interview/utils/api_interactions.py
+++ b/user-study/gpt4-responses/v2_interview/utils/api_interactions.py
@@ -12,7 +12,7 @@ def get_llm_heatmap_description(image_path:str) -> str:
             max_tokens = 400,
             messages = 
                 (get_msg(role="user", prompt=USER_INTRO_4)) +\
-                get_msg_with_image(role="user", prompt=USER_HEATMAP_4+TOKENS_LOW, image=image_path)
+                get_msg_with_image(role="user", prompt=USER_HEATMAP_4+" "+TOKENS_LOW, image=image_path)
         )
     actual_response = response["choices"][0]["message"]["content"]
     return actual_response
@@ -34,3 +34,6 @@ def generate_heatmap_descriptions(question_IDs:[int]) -> None:
     heatmaps_df.reset_index()
     heatmaps_df.to_csv("heatmap_descriptions.csv", na_rep='NA', index=False, quoting=csv.QUOTE_NONNUMERIC)
 
+def get_heatmap_descriptions() -> dict[int, str]:
+    heatmaps_df = pd.read_csv("heatmap_descriptions.csv")
+    return heatmaps_df.to_dict('records')

--- a/user-study/gpt4-responses/v2_interview/utils/file_interactions.py
+++ b/user-study/gpt4-responses/v2_interview/utils/file_interactions.py
@@ -49,3 +49,7 @@ def read_human_data(path_to_csv:str, n=5, selection='first') -> pd.DataFrame:
     df = df.rename(columns={"Q_8" : "Q_4"})
 
     return df
+
+def get_heatmap_descriptions() -> dict[int, str]:
+    heatmaps_df = pd.read_csv("heatmap_descriptions.csv")
+    return heatmaps_df.to_dict('records')

--- a/user-study/gpt4-responses/v2_interview/utils/file_interactions.py
+++ b/user-study/gpt4-responses/v2_interview/utils/file_interactions.py
@@ -51,5 +51,10 @@ def read_human_data(path_to_csv:str, n=5, selection='first') -> pd.DataFrame:
     return df
 
 def get_heatmap_descriptions() -> dict[int, str]:
+    """Reads all available heatmap descriptions from csv files.
+    
+    Returns:
+        ([dict[int, str]]) : a dict containing all heatmap descriptions, keys are question numbers
+    """
     heatmaps_df = pd.read_csv("heatmap_descriptions.csv")
     return heatmaps_df.to_dict('records')

--- a/user-study/gpt4-responses/v2_interview/utils/file_interactions.py
+++ b/user-study/gpt4-responses/v2_interview/utils/file_interactions.py
@@ -2,6 +2,21 @@
 import pandas as pd
 import random
 
+# ------------------------------------------------ FILE NAMES ----------------------------------------
+
+RESULT_FILES = {
+    1 : "out/simulated_interview_results_1.csv",
+    2 : "out/simulated_interview_results_2.csv",
+    3 : "out/simulated_interview_results_3.csv",
+    4 : "out/simulated_interview_results_4.csv"
+}
+
+PROTOCOL_FILES = {
+    1 : "out/interview_protocol_1.txt",
+    2 : "out/interview_protocol_2.txt",
+    3 : "out/interview_protocol_3.txt",
+    4 : "out/interview_protocol_4.txt"
+}
 
 # ----------------------------------------------- During interview ---------------------------------------------------------------
 

--- a/user-study/gpt4-responses/v2_interview/utils/prompts.py
+++ b/user-study/gpt4-responses/v2_interview/utils/prompts.py
@@ -221,3 +221,22 @@ USER_AGREEMENT_ANSWER = "Answer with the number only."
 #     "2) Choose the bird which you gave the highest rating.\n"\
 #     "3) Answer with your chosen bird species only using one of the following four options: "\
 #     "Crested Auklet, Least Auklet, Parakeet Auklet, Rhinoceros Auklet"
+
+# ================================================= DICT ==========================
+
+
+USER_PROMPTS = {
+    (1, "intro") : USER_INTRO_1,
+    (1, "profiling") : USER_PROFILING_1,
+    (1, "question") : USER_QUESTION_1,
+    (2, "intro") : USER_INTRO_2,
+    (2, "profiling") : USER_PROFILING_2,
+    (2, "question") : USER_QUESTION_2,
+    (3, "intro") : USER_INTRO_3,
+    (3, "profiling") : USER_PROFILING_3,
+    (3, "question") : USER_QUESTION_3,
+    (4, "intro") : USER_INTRO_4,
+    (4, "profiling") : USER_PROFILING_4,
+    (4, "question") : USER_QUESTION_4
+}
+

--- a/user-study/gpt4-responses/v2_interview/utils/prompts.py
+++ b/user-study/gpt4-responses/v2_interview/utils/prompts.py
@@ -237,6 +237,7 @@ USER_PROMPTS = {
     (3, "question") : USER_QUESTION_3,
     (4, "intro") : USER_INTRO_4,
     (4, "profiling") : USER_PROFILING_4,
-    (4, "question") : USER_QUESTION_4
+    (4, "question") : USER_QUESTION_4,
+    (4, "heatmap") : USER_HEATMAP_4
 }
 

--- a/user-study/gpt4-responses/v2_interview/v2_interview.py
+++ b/user-study/gpt4-responses/v2_interview/v2_interview.py
@@ -19,7 +19,8 @@ from utils.api_messages import (
 
 from utils.file_interactions import (
     save_result_df,
-    read_human_data
+    read_human_data,
+    get_heatmap_descriptions
 )
 
 from utils.questionnaire import (
@@ -38,8 +39,7 @@ from utils.answer_processing import (
 )
 
 from utils.api_interactions import (
-    generate_heatmap_descriptions,
-    get_heatmap_descriptions
+    generate_heatmap_descriptions
 )
 
 RESULT_FILES = {

--- a/user-study/gpt4-responses/v2_interview/v2_interview.py
+++ b/user-study/gpt4-responses/v2_interview/v2_interview.py
@@ -42,6 +42,20 @@ from utils.api_interactions import (
     get_heatmap_descriptions
 )
 
+RESULT_FILES = {
+    1 : "out/simulated_interview_results_1.csv",
+    2 : "out/simulated_interview_results_2.csv",
+    3 : "out/simulated_interview_results_3.csv",
+    4 : "out/simulated_interview_results_4.csv"
+}
+
+PROTOCOL_FILES = {
+    1 : "out/interview_protocol_1.txt",
+    2 : "out/interview_protocol_2.txt",
+    3 : "out/interview_protocol_3.txt",
+    4 : "out/interview_protocol_4.txt"
+}
+
 # openai.api_key = os.environ["OPENAI_API_KEY"]
 
 def initialize_parser():
@@ -151,7 +165,7 @@ def single_prediction(user : UserProfile, image_path : str, q_num : int, profili
     # print(QUESTION)
 
     # Get gpt-4 response and add the question + answer in the protocol
-    with open("out/interview_protocol.txt", mode="a+") as f:
+    with open(PROTOCOL_FILES[variation], mode="a+") as f:
         f.write("Simulated user {u} answering question {i}:\n".format(u=user.user_background['id'], i=q_num))
         if profiling_level == 'full':
             f.write(user.profiling_prompt)
@@ -198,7 +212,7 @@ def simulate_interviews(question_paths:[(int, str)], profiles:[UserProfile], pro
             heatmap_descriptions (dict[int, str]) : pre-generated descriptions of the heatmaps (for prompt variation 4)
     """
     # find (previous) results    
-    results_df = pd.read_csv("out/simulated_interview_results.csv", index_col = "id", keep_default_na=False)
+    results_df = pd.read_csv(RESULT_FILES[variation], index_col = "id", keep_default_na=False)
     #results_df['LLM_Q2'] = 'NA'
 
     birds = [bird.value.lower() for bird in Auklets]

--- a/user-study/gpt4-responses/v2_interview/v2_interview.py
+++ b/user-study/gpt4-responses/v2_interview/v2_interview.py
@@ -240,7 +240,7 @@ def simulate_interviews(question_paths:[(int, str)], profiles:[UserProfile], pro
             if results_df.at[user_id, question].lower() not in birds:
                 try:
                     if variation==4:
-                        results_df.at[user_id, question] = single_prediction(user, q_path, q_index, profiling_level, heatmap_descriptions[q_index])
+                        results_df.at[user_id, question] = single_prediction(user, q_path, q_index, profiling_level, variation, heatmap_descriptions[q_index])
                     else:
                         results_df.at[user_id, question] = single_prediction(user, q_path, q_index, profiling_level, variation)
                 except Exception as e:

--- a/user-study/gpt4-responses/v2_interview/v2_interview.py
+++ b/user-study/gpt4-responses/v2_interview/v2_interview.py
@@ -42,20 +42,6 @@ from utils.api_interactions import (
     generate_heatmap_descriptions
 )
 
-RESULT_FILES = {
-    1 : "out/simulated_interview_results_1.csv",
-    2 : "out/simulated_interview_results_2.csv",
-    3 : "out/simulated_interview_results_3.csv",
-    4 : "out/simulated_interview_results_4.csv"
-}
-
-PROTOCOL_FILES = {
-    1 : "out/interview_protocol_1.txt",
-    2 : "out/interview_protocol_2.txt",
-    3 : "out/interview_protocol_3.txt",
-    4 : "out/interview_protocol_4.txt"
-}
-
 # openai.api_key = os.environ["OPENAI_API_KEY"]
 
 def initialize_parser():

--- a/user-study/gpt4-responses/v2_interview/v2_interview.py
+++ b/user-study/gpt4-responses/v2_interview/v2_interview.py
@@ -169,6 +169,12 @@ def single_prediction(user : UserProfile, image_path : str, q_num : int, profili
         f.write("Simulated user {u} answering question {i}:\n".format(u=user.user_background['id'], i=q_num))
         if profiling_level == 'full':
             f.write(user.profiling_prompt)
+        if variation == 4:
+            f.write(USER_PROMPTS[(4, "intro")])
+            f.write(USER_PROMPTS[(4, "heatmap")])
+            f.write("\n")
+            f.write(heatmap_description)
+            f.write("\n")
         f.write("\n")
         f.write(QUESTION)
         f.write("\n")


### PR DESCRIPTION
### Heatmap descriptions
- new function(s) for asking LLM for heatmap descriptions, which are stored in ``heatmap_descriptions.csv`
   - the csv file has 2 columns: question ID and corresponding description
- I generated descriptions for questions 1, 5, 7
  - 1 (0-Crested.png) seems fine
  - for 5 (4-Crested.png) and especially 7 (16-Least.png), there are parts of the birds' chests highlighted in the image, but the generated descriptions do not mention that
  - in an earlier commit (`added function for generating heatmap descriptions`), I had accidentally left out the prompt that asked to keep tokens low - but it still did not mention the bird's chest for question 7
  - maybe we can adapt the prompt to say something like ```Describe all areas of the bird that are highlighted in red by the heatmap```?

### Prompt Variations
- command line option for choosing a `--variation` of our prompts, as a default it will choose `1` so that minimal tokens will be used when forgetting to choose a variation explicitly
- also: different output files for variations aka resolves #35 

### Variation 4: Different Logic
- aka #35 
- for variation 4, the heatmap descriptions will be generated before starting the interview
- all variants can still use the same `single_prediction` function
  - used to be `single_interview` but I think this name makes more sense?
  - the idea was that there could also be a `single_agreement` function for the agreement questions
- there are individual functions for the main API call (`llm_prediction_123` and `llm_prediction_4`) which will be called depending on variation given as command line argument
- there is no explicit error handling for missing heatmap descriptions (yet), the access to the descriptions is in the same try/except block as the `single_prediction` call...
- I haven't tried this with the actual API call yet, just had it print out the message it would send to the API - i can try tomorrow